### PR TITLE
Update 10-wireguard_failover.sh

### DIFF
--- a/on_boot.d/10-wireguard_failover.sh
+++ b/on_boot.d/10-wireguard_failover.sh
@@ -22,8 +22,8 @@ do
 	for config in "${wireguard_interface[@]}"
 		do
 			if [ -f /etc/wireguard/$wireguard_interface.conf ]; then
-				using_table=`cat /var/log/messages | grep wan-failover-groups | grep "table" | tail -n1 | grep -oE '201|202|203'`
-				if [ $using_table = 201 ]; then
+				using_table=`cat /var/log/messages | grep wan-failover-groups | grep "table" | tail -n1 | grep -oE 'table 201|table 202|table 203' | grep -oE '201|202|203'`
+				if [ "$using_table" = 201 ]; then
 					sleep_time=$sleeptime
 					[ ! -z "$failover" ] || failover=0
 					if [ $failover = 1 ]; then
@@ -33,7 +33,7 @@ do
 						[ $logfile = 1 ] && echo "$(date +%F_%H-%M-%S) WAN" >> /mnt/data/log/wireguard_failover
 					fi
 				else
-					if [ $using_table = 202 ] || [ $using_table = 203 ]; then
+					if [ "$using_table" = 202 ] || [ "$using_table" = 203 ]; then
 						if [ $logfile = 1 ]; then
 							[ ! -z "$failover" ] || failover=0
 							[ $failover = 0 ] && echo "$(date +%F_%H-%M-%S) WAN_Failover" >> /mnt/data/log/wireguard_failover


### PR DESCRIPTION
Fix error:
/mnt/data/wireguard-failover/10-wireguard-failover.sh: line 36: [: too many arguments  /mnt/data/wireguard-failover/10-wireguard-failover.sh: line 26: [: too many arguments


After upgrade to UNIFI OS 2.4+